### PR TITLE
Melhorias na validação da BibTeX key

### DIFF
--- a/src/main/java/net/sf/jabref/collab/ChangeDisplayDialog.java
+++ b/src/main/java/net/sf/jabref/collab/ChangeDisplayDialog.java
@@ -34,6 +34,7 @@ import javax.swing.JTree;
 import javax.swing.event.TreeSelectionEvent;
 import javax.swing.event.TreeSelectionListener;
 import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.TreeNode;
 
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.undo.NamedCompound;
@@ -100,12 +101,12 @@ class ChangeDisplayDialog extends JDialog implements TreeSelectionListener {
             // Perform all accepted changes:
             // Store all edits in an Undoable object:
             NamedCompound ce = new NamedCompound(Localization.lang("Merged external changes"));
-            Enumeration<Change> enumer = root.children();
+            Enumeration<TreeNode> enumer = root.children();
             boolean anyDisabled = false;
-            for (Change c : Collections.list(enumer)) {
+            for (TreeNode c : Collections.list(enumer)) {
                 boolean allAccepted = false;
-                if (c.isAcceptable() && c.isAccepted()) {
-                    allAccepted = c.makeChange(panel, localSecondary, ce);
+                if (((Change) c).isAcceptable() && ((Change) c).isAccepted()) {
+                    allAccepted = ((Change) c).makeChange(panel, localSecondary, ce);
                 }
 
                 if (!allAccepted) {

--- a/src/main/java/net/sf/jabref/collab/EntryChange.java
+++ b/src/main/java/net/sf/jabref/collab/EntryChange.java
@@ -23,6 +23,7 @@ import java.util.TreeSet;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JScrollPane;
+import javax.swing.tree.TreeNode;
 
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.undo.NamedCompound;
@@ -86,10 +87,10 @@ class EntryChange extends Change {
     public boolean makeChange(BasePanel panel, BibDatabase secondary, NamedCompound undoEdit) {
         boolean allAccepted = true;
 
-        Enumeration<Change> e = children();
-        for (Change c : Collections.list(e)) {
-            if (c.isAcceptable() && c.isAccepted()) {
-                c.makeChange(panel, secondary, undoEdit);
+        Enumeration<TreeNode> e = children();
+        for (TreeNode c : Collections.list(e)) {
+            if (((Change) c).isAcceptable() && ((Change) c).isAccepted()) {
+                ((EntryChange) c).makeChange(panel, secondary, undoEdit);
             } else {
                 allAccepted = false;
             }

--- a/src/main/java/net/sf/jabref/gui/FindUnlinkedFilesDialog.java
+++ b/src/main/java/net/sf/jabref/gui/FindUnlinkedFilesDialog.java
@@ -49,6 +49,7 @@ import java.util.Vector;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.swing.AbstractAction;
+import javax.swing.AbstractButton;
 import javax.swing.Action;
 import javax.swing.BorderFactory;
 import javax.swing.DefaultListCellRenderer;
@@ -464,7 +465,7 @@ public class FindUnlinkedFilesDialog extends JDialog {
     private void expandTree(JTree currentTree, TreePath parent, boolean expand) {
         TreeNode node = (TreeNode) parent.getLastPathComponent();
         if (node.getChildCount() >= 0) {
-            for (Enumeration<TreeNode> e = node.children(); e.hasMoreElements();) {
+            for (Enumeration<TreeNode> e = (Enumeration<TreeNode>) node.children(); e.hasMoreElements();) {
                 TreePath path = parent.pathByAddingChild(e.nextElement());
                 expandTree(currentTree, path, expand);
             }
@@ -689,14 +690,14 @@ public class FindUnlinkedFilesDialog extends JDialog {
      */
     private List<File> getFileListFromNode(CheckableTreeNode node) {
         List<File> filesList = new ArrayList<>();
-        Enumeration<CheckableTreeNode> children = node.depthFirstEnumeration();
+        Enumeration<TreeNode> children = node.depthFirstEnumeration();
         List<CheckableTreeNode> nodesToRemove = new ArrayList<>();
-        for (CheckableTreeNode child : Collections.list(children)) {
-            if (child.isLeaf() && child.isSelected()) {
-                File nodeFile = ((FileNodeWrapper) child.getUserObject()).file;
+        for (TreeNode child : Collections.list(children)) {
+            if (child.isLeaf() && ((AbstractButton) child).isSelected()) {
+                File nodeFile = ((FileNodeWrapper) ((DefaultMutableTreeNode) child).getUserObject()).file;
                 if ((nodeFile != null) && nodeFile.isFile()) {
                     filesList.add(nodeFile);
-                    nodesToRemove.add(child);
+                    nodesToRemove.add((CheckableTreeNode) child);
                 }
             }
         }
@@ -1131,9 +1132,9 @@ public class FindUnlinkedFilesDialog extends JDialog {
 
         public void setSelected(boolean bSelected) {
             isSelected = bSelected;
-            Enumeration<CheckableTreeNode> tmpChildren = this.children();
-            for (CheckableTreeNode child : Collections.list(tmpChildren)) {
-                child.setSelected(bSelected);
+            Enumeration<TreeNode> tmpChildren = this.children();
+            for (TreeNode child : Collections.list(tmpChildren)) {
+                ((AbstractButton) child).setSelected(bSelected);
             }
 
         }

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -1100,7 +1100,8 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
                 if ((cleaned == null) || cleaned.equals(newValue)) {
                     textField.setValidBackgroundColor();
                 } else {
-                    JOptionPane.showMessageDialog(frame, Localization.lang("Invalid BibTeX key"),
+                    JOptionPane.showMessageDialog(frame, Localization.lang(
+                            "Invalid BibTeX key\nMust begin with a letter and\nhave at least 2 characters\nCan't contain {}(),\\\"#~^'\n"),
                             Localization.lang("Error setting field"), JOptionPane.ERROR_MESSAGE);
                     textField.setInvalidBackgroundColor();
                     return;

--- a/src/main/java/net/sf/jabref/logic/labelpattern/LabelPatternUtil.java
+++ b/src/main/java/net/sf/jabref/logic/labelpattern/LabelPatternUtil.java
@@ -1412,12 +1412,22 @@ public class LabelPatternUtil {
         }
 
         StringBuilder newKey = new StringBuilder();
+        int counter = 0;
         for (int i = 0; i < key.length(); i++) {
             char c = key.charAt(i);
             if (!Character.isWhitespace(c) && ("{}(),\\\"#~^'".indexOf(c) == -1)) {
-                newKey.append(c);
+                if (((counter == 0) && Character.isAlphabetic(c)) || (counter > 0)) {
+                    newKey.append(c);
+                    counter++;
+                }
             }
         }
+        if (counter < 2) {
+            while (newKey.length() > 0) {
+                newKey.deleteCharAt(0);
+            }
+        }
+
 
         // Replace non-English characters like umlauts etc. with a sensible
         // letter or letter combination that bibtex can accept.


### PR DESCRIPTION
Levando as mudanças relacionadas a issue '2 - Padronização de bibtexkey' ao main

```
JabRef versão 3.3 no Linux Mint 20.3 Cinnamon

Sugestão: Nova formatação padrão para bibtexkey, mínimo duas letras começando com letra.

Vantagens:

Impede keys de apenas uma letra.
Deixa as keys padronizadas.
```